### PR TITLE
refactor: replace initialScrollIndex with onContentSizeChange in RulerPicker

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -8,13 +8,13 @@ export default function App() {
     <View style={styles.container}>
       <RulerPicker
         min={0}
+        unit="cm"
         max={240}
         step={1}
         fractionDigits={0}
         initialValue={0}
         onValueChange={(number) => console.log('onValueChange', number)}
         onValueChangeEnd={(number) => console.log('onValueChangeEnd', number)}
-        unit="cm"
       />
     </View>
   );

--- a/src/components/RulerPicker.tsx
+++ b/src/components/RulerPicker.tsx
@@ -258,14 +258,13 @@ export const RulerPicker = ({
       step,
     ]
   );
-  const onContentSizeChange = useCallback(() => {
+  function onContentSizeChange() {
     const initialIndex = Math.floor((initialValue - min) / step);
     listRef.current?.scrollToOffset({
       offset: initialIndex * (stepWidth + gapBetweenSteps),
       animated: false,
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }
 
   return (
     <View style={{ width, height }}>

--- a/src/components/RulerPicker.tsx
+++ b/src/components/RulerPicker.tsx
@@ -10,7 +10,11 @@ import {
 } from 'react-native';
 import type { NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
 
-import { AnimatedFlashList, ListRenderItem } from '@shopify/flash-list';
+import {
+  AnimatedFlashList,
+  FlashList,
+  ListRenderItem,
+} from '@shopify/flash-list';
 
 import { RulerPickerItem, RulerPickerItemProps } from './RulerPickerItem';
 import { calculateCurrentValue } from '../utils/';
@@ -141,6 +145,7 @@ export const RulerPicker = ({
 }: RulerPickerProps) => {
   const itemAmount = (max - min) / step;
   const arrData = Array.from({ length: itemAmount + 1 }, (_, index) => index);
+  const listRef = useRef<FlashList<typeof arrData>>(null);
 
   const stepTextRef = useRef<TextInput>(null);
   const prevValue = useRef<string>(initialValue.toFixed(fractionDigits));
@@ -253,10 +258,19 @@ export const RulerPicker = ({
       step,
     ]
   );
+  const onContentSizeChange = useCallback(() => {
+    const initialIndex = Math.floor((initialValue - min) / step);
+    listRef.current?.scrollToOffset({
+      offset: initialIndex * (stepWidth + gapBetweenSteps),
+      animated: false,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <View style={{ width, height }}>
       <AnimatedFlashList
+        ref={listRef}
         data={arrData}
         keyExtractor={(_, index) => index.toString()}
         renderItem={renderItem}
@@ -268,7 +282,7 @@ export const RulerPicker = ({
         snapToOffsets={arrData.map(
           (_, index) => index * (stepWidth + gapBetweenSteps)
         )}
-        initialScrollIndex={Math.floor((initialValue - min) / step)}
+        onContentSizeChange={onContentSizeChange}
         snapToAlignment="start"
         decelerationRate={decelerationRate}
         estimatedFirstItemOffset={0}


### PR DESCRIPTION
This PR addresses an issue with the `RulerPicker` component where the `initialScrollIndex` prop was not setting the scroll position as expected. The root cause seemed to be that the scroll index was calculated before the content dimensions were fully known.

Changes made:

1. Removed the `initialScrollIndex` prop from the `RulerPicker` component.
2. Added an `onContentSizeChange` prop to the `RulerPicker` component.
3. Inside the `onContentSizeChange` callback, calculated the initial scroll position based on the `initialValue`, `stepWidth` and `gapBetweenSteps` props, and then programmatically scroll to that position.

This change ensures that the `RulerPicker` correctly displays the initial value passed to it. It was tested with a variety of initial values and found to work as expected.

https://github.com/rnheroes/react-native-ruler-picker/assets/68515357/82fca3aa-3c20-4476-8f05-d767b14ef2c8